### PR TITLE
Default to HTTP 500

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,8 +42,9 @@ function ErrorHTTP(message, status) {
         status = message;
         message = null;
     }
+    status = status || 500;
     if (!message) {
-        message = http.STATUS_CODES[status] || 'Unknown';
+        message = http.STATUS_CODES[status];
     }
 
     Error.call(this, message);

--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ function showError(err, req, res, next) {
     if (err.status >= 500) {
         err.url = req.url;
         err.method = req.method;
-        err['x-amz-cf-id'] = req.headers['x-amz-cf-id'];
         logger.error(err);
         err.message = 'Internal Server Error';
     }

--- a/test.js
+++ b/test.js
@@ -114,7 +114,11 @@ tape('ErrorHTTP', function(t) {
 
     err = new errors.ErrorHTTP('Server error');
     t.equal(err.message, 'Server error', 'sets message');
-    t.equal(err.status, undefined, 'does not set status without status');
+    t.equal(err.status, 500, 'status defaults to 500');
+
+    err = new errors.ErrorHTTP();
+    t.equal(err.message, 'Internal Server Error', 'sets message');
+    t.equal(err.status, 500, 'status defaults to 500');
 
     t.equal(Object.getPrototypeOf(err).toString(), 'Error', 'inherits from Error');
 


### PR DESCRIPTION
Set the error's status to 500 if a status isn't explicitly isn't passed in during construction. Also, removes the `x-amz-cf-id` header.