### PR TITLE
Extra properties get sent to the client

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,19 @@ function showError(err, req, res, next) {
         err.message = 'Internal Server Error';
     }
 
-    res.jsonp(err.status, {message: err.message});
+    var data = { message:err.message };
+
+    // For non-500 ErrorHTTP objects send over any additional keys.
+    // This error is one that we crafted ourselves deliberately for
+    // public consumption.
+    if (err instanceof ErrorHTTP && err.status <= 500) {
+        for (var k in err) {
+            if (k === 'status') continue;
+            data[k] = err[k];
+        }
+    }
+
+    res.jsonp(err.status, data);
 }
 
 function notFound(req, res, next) {

--- a/test.js
+++ b/test.js
@@ -65,6 +65,32 @@ tape('showError - not 500', function(t) {
     t.end();
 });
 
+tape('showError - ErrorHTTP with 404 status property with extra properties', function(t) {
+    var logged = 0;
+    var status;
+    var data;
+
+    var req = new MockReq();
+    var res = new MockRes();
+    res.jsonp = function(s, d) {
+        status = s;
+        data = d;
+    };
+
+    var err = new errors.ErrorHTTP('Tileset does not exist', 404);
+    err.details = 'here are the details';
+    var origlog = console.log;
+    console.log = function() { logged++; };
+    errors.showError(err, req, res, function(){});
+    console.log = origlog;
+
+    t.equal(logged, 0, 'message not logged');
+    t.equal(status, 404);
+    t.deepEqual(data, { message: 'Tileset does not exist', details: 'here are the details' });
+
+    t.end();
+});
+
 tape('notFound', function(t) {
     var req = new MockReq();
     var res = new MockRes();


### PR DESCRIPTION
Send any extra properties attached on instances of `ErrorHTTP()` to the client. We craft these errors specifically for public consumption.