### PR TITLE
status -> http_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
+
+## Unreleased
+
+Keep future unreleased changes here
+
+## 3.0.0
+
+### Changed
+
+- The internal attribute `status` was changed to `http_status` to make sure for `status` keys in the response body. If you are using `ErrorHTTP` this change is transparent, but if you are creating own error objects these need to be changed from `status` to` http_status`

--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@ module.exports.notFound = notFound;
 module.exports.ErrorHTTP = ErrorHTTP;
 
 function showError(err, req, res, next) {
-    err.status = err.status || 500;
+    err.http_status = err.http_status || 500;
 
     // Output unexpected errors to console but hide them from public eyes.
-    if (err.status >= 500) {
+    if (err.http_status >= 500) {
         err.url = req.url;
         err.method = req.method;
         logger.error(err);
@@ -22,34 +22,35 @@ function showError(err, req, res, next) {
     // For non-500 ErrorHTTP objects send over any additional keys.
     // This error is one that we crafted ourselves deliberately for
     // public consumption.
-    if (err instanceof ErrorHTTP && err.status < 500) {
+    if (err instanceof ErrorHTTP && err.http_status < 500) {
         for (var k in err) {
-            if (k === 'status') continue;
+            if (k === 'http_status') continue;
             data[k] = err[k];
         }
     }
 
-    res.status(err.status).jsonp(data);
+    res.status(err.http_status).jsonp(data);
+    next();
 }
 
 function notFound(req, res, next) {
     next(new ErrorHTTP(404));
 }
 
-function ErrorHTTP(message, status) {
+function ErrorHTTP(message, http_status) {
     if (typeof message === 'number') {
-        status = message;
+        http_status = message;
         message = null;
     }
-    status = status || 500;
+    http_status = http_status || 500;
     if (!message) {
-        message = http.STATUS_CODES[status];
+        message = http.STATUS_CODES[http_status];
     }
 
     Error.call(this, message);
     Error.captureStackTrace(this, arguments.callee);
     this.message = message;
-    this.status = status;
+    this.http_status = http_status;
 }
 
 ErrorHTTP.prototype = Object.create(Error.prototype);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Error middleware for express apps",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "ISC",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "main": "./index",
   "dependencies": {
     "fastlog": "0.1.0"

--- a/test.js
+++ b/test.js
@@ -31,7 +31,6 @@ tape('showError', function(t) {
     errors.showError(new Error('fatal'), req, res, function(){});
     console.log = origlog;
 
-
     t.equal(logged, 1, 'message logged');
     t.equal(res.status, 500);
     t.deepEqual(res.data, { message: 'Internal Server Error' });
@@ -47,7 +46,7 @@ tape('showError - not 500', function(t) {
 
     var err = {
         message: 'Tileset does not exist',
-        status: 404
+        http_status: 404
     };
     var origlog = console.log;
     console.log = function() { logged++; };
@@ -69,6 +68,7 @@ tape('showError - ErrorHTTP with 404 status property with extra properties', fun
 
     var err = new errors.ErrorHTTP('Tileset does not exist', 404);
     err.details = 'here are the details';
+    err.status = 'NOT_FOUND';
     var origlog = console.log;
     console.log = function() { logged++; };
     errors.showError(err, req, res, function(){});
@@ -76,7 +76,11 @@ tape('showError - ErrorHTTP with 404 status property with extra properties', fun
 
     t.equal(logged, 0, 'message not logged');
     t.equal(res.status, 404);
-    t.deepEqual(res.data, { message: 'Tileset does not exist', details: 'here are the details' });
+    t.deepEqual(res.data, {
+        status: 'NOT_FOUND',
+        message: 'Tileset does not exist',
+        details: 'here are the details'
+    });
 
     t.end();
 });
@@ -86,7 +90,7 @@ tape('notFound', function(t) {
     var res = new MockRes();
 
     errors.notFound(req, res, function(err) {
-        t.equal(err.status, 404);
+        t.equal(err.http_status, 404);
         t.deepEqual(err.message, 'Not Found');
         t.end();
     });
@@ -95,20 +99,20 @@ tape('notFound', function(t) {
 tape('ErrorHTTP', function(t) {
     var err = new errors.ErrorHTTP('Testing error', 500);
     t.equal(err.message, 'Testing error', 'sets message');
-    t.equal(err.status, 500, 'sets status code');
+    t.equal(err.http_status, 500, 'sets status code');
     t.ok(err.stack, 'has stack trace');
 
     err = new errors.ErrorHTTP(404);
     t.equal(err.message, 'Not Found', 'sets message based on status code');
-    t.equal(err.status, 404, 'sets status');
+    t.equal(err.http_status, 404, 'sets status');
 
     err = new errors.ErrorHTTP('Server error');
     t.equal(err.message, 'Server error', 'sets message');
-    t.equal(err.status, 500, 'status defaults to 500');
+    t.equal(err.http_status, 500, 'status defaults to 500');
 
     err = new errors.ErrorHTTP();
     t.equal(err.message, 'Internal Server Error', 'sets message');
-    t.equal(err.status, 500, 'status defaults to 500');
+    t.equal(err.http_status, 500, 'status defaults to 500');
 
     t.equal(Object.getPrototypeOf(err).toString(), 'Error', 'inherits from Error');
 


### PR DESCRIPTION
We have a project that needs to put a `status` key into the response body of errors. This is currently not possible, since the `status` key is already blocked by the http status. Thus this PR moves it to `http_status`.

If `ErrorHTTP` is used, then this change is transparent. If a custom error is used (e.g. in the test suite of mapbox-error) than the `status` key needs to be changed to `http_status`, thus the major version increase.