### PR TITLE
Allow message as object to control response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
+
+## Unreleased
+
+Keep future unreleased changes here
+
+## 2.2.0
+
+### Added
+
+- `ErroHTTP` and `showError` now accept the message as object as well, which allows more control over the response body. The object needs to have a `message.message` key.

--- a/README.md
+++ b/README.md
@@ -2,23 +2,38 @@
 
 ### Generic error middleware for express apps
 
-#### usage:
+#### Usage
+
 ``` javascript
 var errors = require('mapbox-error');
 var ErrorHTTP = errors.ErrorHTTP;
 var server = require('express')();
 
 // use ErrorHTTP to associate a status code and message to an Error object
+//
+// To the user this will return:
+//   HTTP/1.1 400 Bad request
+//   {"message":"Error for the sake of errors"}
 server.get('/error', function(req, res, next) {
   return next(new ErrorHTTP('Error for the sake of errors', 400);
+});
+
+// use ErrorHTTP to associate a status code and message object to an Error object
+// To the user this will return:
+//   HTTP/1.1 400 Bad request
+//   {"message":"Error for the sake of errors","status":"GOOD_ERRORS_ARE_GOOD"}
+server.get('/error', function(req, res, next) {
+  return next(new ErrorHTTP({
+    message: 'Error for the sake of errors',
+    status: 'GOOD_ERRORS_ARE_GOOD'
+  }, 400);
 });
 
 // put these after other routes and uses have been defined
 server.use(errors.showError);
 server.use(errors.notFound);
-
 ```
 
-#### test:
+#### Tests
 
 `npm test`

--- a/index.js
+++ b/index.js
@@ -17,19 +17,25 @@ function showError(err, req, res, next) {
         err.message = 'Internal Server Error';
     }
 
-    var data = { message:err.message };
+    var data;
+    if (typeof err.message === 'object') {
+        data = err.message;
+    } else {
+        data = { message: err.message };
 
-    // For non-500 ErrorHTTP objects send over any additional keys.
-    // This error is one that we crafted ourselves deliberately for
-    // public consumption.
-    if (err instanceof ErrorHTTP && err.status < 500) {
-        for (var k in err) {
-            if (k === 'status') continue;
-            data[k] = err[k];
+        // For non-500 ErrorHTTP objects without own message body we send over any additional keys.
+        // This error is one that we crafted ourselves deliberately for
+        // public consumption.
+        if (err instanceof ErrorHTTP && err.status < 500) {
+            for (var k in err) {
+                if (k === 'status') continue;
+                data[k] = err[k];
+            }
         }
     }
 
     res.status(err.status).jsonp(data);
+    next();
 }
 
 function notFound(req, res, next) {
@@ -41,12 +47,13 @@ function ErrorHTTP(message, status) {
         status = message;
         message = null;
     }
+
     status = status || 500;
     if (!message) {
         message = http.STATUS_CODES[status];
     }
 
-    Error.call(this, message);
+    Error.call(this, typeof message === 'object' ? message.message : message);
     Error.captureStackTrace(this, arguments.callee);
     this.message = message;
     this.status = status;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Error middleware for express apps",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "ISC",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "./index",
   "dependencies": {
     "fastlog": "0.1.0"

--- a/test.js
+++ b/test.js
@@ -98,6 +98,11 @@ tape('ErrorHTTP', function(t) {
     t.equal(err.status, 500, 'sets status code');
     t.ok(err.stack, 'has stack trace');
 
+    var err = new errors.ErrorHTTP({ message: 'Testing error', details: 'more details' }, 500);
+    t.deepEqual(err.message, { message: 'Testing error', details: 'more details' }, 'sets message object');
+    t.equal(err.status, 500, 'sets status code');
+    t.ok(err.stack, 'has stack trace');
+
     err = new errors.ErrorHTTP(404);
     t.equal(err.message, 'Not Found', 'sets message based on status code');
     t.equal(err.status, 404, 'sets status');


### PR DESCRIPTION
Another try for #10 

This change is forward-compatible, but allows to set the `status` key on the HTTP response.