### PR TITLE
Fix regression of error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+## 3.0.1
+
+* Fixed regression in `showError` handler
+
 ## 3.0.0
 
 * es6 support, move to @mapbox namespace on npm [#16](https://github.com/mapbox/mapbox-error/pull/16)

--- a/index.js
+++ b/index.js
@@ -64,7 +64,9 @@ function fastErrorHTTP(code, status) {
  * Any status codes <500 are assumed to contain error messages crafted
  * for public consumption.
  */
-function showError(err, req, res) {
+
+// NOTE: next is needed, even if not used, per https://expressjs.com/en/guide/using-middleware.html
+function showError(err, req, res, next) {
   err.status = err.status || 500;
 
   // Output unexpected errors to console but hide them from public eyes.

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function fastErrorHTTP(code, status) {
  */
 
 // NOTE: next is needed, even if not used, per https://expressjs.com/en/guide/using-middleware.html
-function showError(err, req, res, next) {
+function showError(err, req, res, next) { // eslint-disable-line no-unused-vars
   err.status = err.status || 500;
 
   // Output unexpected errors to console but hide them from public eyes.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Error middleware for express apps",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "ISC",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "./index",
   "dependencies": {
     "fastlog": "0.1.0"

--- a/test.js
+++ b/test.js
@@ -27,10 +27,11 @@ tape('showError', (t) => {
 
   const req = new MockReq();
   const res = new MockRes();
+  const next = function () {};
 
   const origlog = console.log;
   console.log = function() { logged++; };
-  errors.showError(new Error('fatal'), req, res, () => {});
+  errors.showError(new Error('fatal'), req, res, next, () => {});
   console.log = origlog;
 
   t.equal(logged, 1, 'message logged');
@@ -45,6 +46,7 @@ tape('showError - not 500', (t) => {
 
   const req = new MockReq();
   const res = new MockRes();
+  const next = function () {};
 
   const err = {
     message: 'Tileset does not exist',
@@ -52,7 +54,7 @@ tape('showError - not 500', (t) => {
   };
   const origlog = console.log;
   console.log = function() { logged++; };
-  errors.showError(err, req, res, () => {});
+  errors.showError(err, req, res, next, () => {});
   console.log = origlog;
 
   t.equal(logged, 0, 'message not logged');
@@ -67,12 +69,13 @@ tape('showError - ErrorHTTP with 404 status property with extra properties', (t)
 
   const req = new MockReq();
   const res = new MockRes();
+  const next = function () {};
 
   const err = new errors.ErrorHTTP('Tileset does not exist', 404);
   err.details = 'here are the details';
   const origlog = console.log;
   console.log = function() { logged++; };
-  errors.showError(err, req, res, () => {});
+  errors.showError(err, req, res, next, () => {});
   console.log = origlog;
 
   t.equal(logged, 0, 'message not logged');


### PR DESCRIPTION
#16 broke the `showError` handler. This became evident downstream in api-assets which started sending error responses as HTML rather than JSON because `showError` was being ignored at https://github.com/mapbox/api-assets/blob/65375e8bbe7c027a785486e8240f6f5c5a486615/index.js#L155

> Error-handling middleware always takes four arguments. You must provide four arguments to identify it as an error-handling middleware function. Even if you don’t need to use the next object, you must specify it to maintain the signature. Otherwise, the next object will be interpreted as regular middleware and will fail to handle errors.

https://expressjs.com/en/guide/using-middleware.html

/cc @mapsam 