### PR TITLE
add default cache-control to error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 
 node_js:
-  - "6"
-  - "8"
   - "10"
+  - "12"
 
 script:
   - npm run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.1.0
+
+* Added default cache-control within `showError` handler
+* No longer test on EOL versions of Node
+
 ## 3.0.1
 
 * Fixed regression in `showError` handler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 4.0.0
+## 3.1.0
 
-* Added default cache-control within `showError` handler [#19](https://github.com/mapbox/mapbox-error/pull/19)
+* Add ability to set default cache-control in `showError` [#19](https://github.com/mapbox/mapbox-error/pull/19)
 * No longer test on EOL versions of Node
 
 ## 3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 3.1.0
+## 4.0.0
 
-* Added default cache-control within `showError` handler
+* Added default cache-control within `showError` handler [#19](https://github.com/mapbox/mapbox-error/pull/19)
 * No longer test on EOL versions of Node
 
 ## 3.0.1

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function showError(err, req, res, next) { // eslint-disable-line no-unused-vars
   // public consumption.
   if (err instanceof ErrorHTTP && err.status < 500) {
     for (const k in err) {
-      if (k === 'status') continue;
+      if (k === 'status' || k === 'cache') continue;
       data[k] = err[k];
     }
   }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const util = require('util');
  * @extends Error
  */
 class ErrorHTTP extends Error {
-  constructor(message, status = 500) {
+  constructor(message, status = 500, cache = 'max-age=60,s-maxage=300') {
     super();
 
     if (typeof message === 'number') {
@@ -25,6 +25,7 @@ class ErrorHTTP extends Error {
     Error.captureStackTrace(this, ErrorHTTP);
     this.message = message;
     this.status = status;
+    this.cache = cache;
   }
 }
 
@@ -89,6 +90,10 @@ function showError(err, req, res, next) { // eslint-disable-line no-unused-vars
     }
   }
 
+  // By default, errors should have shorter custom TTLs rather than
+  // relying on our application's defaults which likely have good
+  // reason to be longer.
+  res.set('Cache-Control', err.cache);
   res.status(err.status).jsonp(data);
 }
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,23 @@ class ErrorHTTP extends Error {
 }
 
 /**
+ * Validate that the provided ttl value is acceptable
+ *
+ * @param {String} ttl - cache-control value you want to validate
+ */
+function validateCacheControl(ttl) {
+
+  if (typeof ttl !== 'string') {
+    throw new TypeError('cache-control ttl must be a string');
+  }
+
+  const acceptedValues = /(must-|no-|public|private|proxy|max-age=|s-maxage=)/;
+  if (!ttl.match(acceptedValues)) {
+    throw new TypeError(`invalid directive ${ttl}`);
+  }
+}
+
+/**
  * Generates a custom error object used for specific error handling.
  * Extends the ErrorHTTP class.
  *
@@ -91,12 +108,14 @@ function showError(err, req, res, next, ttl) { // eslint-disable-line no-unused-
   }
 
   // Allow downstream APIs to provide custom cache-control values
-  // for their errors, while also ensure that we respect any custom
+  // for their errors, while also ensuring that we respect any custom
   // cache-control values set at the ErrorHTTP level.
   if (ttl && !err.ttl) {
+    validateCacheControl(ttl);
     res.set('Cache-Control', ttl);
   }
   if (err.ttl) {
+    validateCacheControl(err.ttl);
     res.set('Cache-Control', err.ttl);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-error",
-  "version": "2.2.0",
+  "version": "3.1.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-error",
-  "version": "3.1.0-dev",
+  "version": "4.0.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-error",
-  "version": "4.0.0-dev2",
+  "version": "3.1.0-dev2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-error",
-  "version": "4.0.0-dev",
+  "version": "4.0.0-dev2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-error",
-  "version": "3.1.0-dev2",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-error",
-  "version": "3.1.0",
+  "version": "3.1.0-dev3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Error middleware for express apps",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "ISC",
-  "version": "3.0.1",
+  "version": "3.1.0-dev",
   "main": "./index",
   "dependencies": {
     "fastlog": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Error middleware for express apps",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "ISC",
-  "version": "4.0.0-dev",
+  "version": "4.0.0-dev2",
   "main": "./index",
   "dependencies": {
     "fastlog": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Error middleware for express apps",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "ISC",
-  "version": "3.1.0-dev",
+  "version": "4.0.0-dev",
   "main": "./index",
   "dependencies": {
     "fastlog": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Error middleware for express apps",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "ISC",
-  "version": "3.1.0-dev2",
+  "version": "3.1.0",
   "main": "./index",
   "dependencies": {
     "fastlog": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Error middleware for express apps",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "ISC",
-  "version": "3.1.0",
+  "version": "3.1.0-dev3",
   "main": "./index",
   "dependencies": {
     "fastlog": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Error middleware for express apps",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "ISC",
-  "version": "4.0.0-dev2",
+  "version": "3.1.0-dev2",
   "main": "./index",
   "dependencies": {
     "fastlog": "0.1.0"

--- a/test.js
+++ b/test.js
@@ -80,7 +80,7 @@ tape('showError - ErrorHTTP with 404 status property with extra properties', (t)
 
   t.equal(logged, 0, 'message not logged');
   t.equal(res.status, 404);
-  t.deepEqual(res.data, { message: 'Tileset does not exist', details: 'here are the details' });
+  t.deepEqual(res.data, { message: 'Tileset does not exist', details: 'here are the details', cache: 'max-age=60,s-maxage=300' });
 
   t.end();
 });
@@ -154,6 +154,7 @@ tape('ErrorHTTP', (t) => {
   err = new errors.ErrorHTTP(404);
   t.equal(err.message, 'Not Found', 'sets message based on status code');
   t.equal(err.status, 404, 'sets status');
+  t.equal(err.cache, 'max-age=60,s-maxage=300');
 
   err = new errors.ErrorHTTP('Server error');
   t.equal(err.message, 'Server error', 'sets message');
@@ -162,6 +163,12 @@ tape('ErrorHTTP', (t) => {
   err = new errors.ErrorHTTP();
   t.equal(err.message, 'Internal Server Error', 'sets message');
   t.equal(err.status, 500, 'status defaults to 500');
+  t.equal(err.cache, 'max-age=60,s-maxage=300', 'sets cache default');
+
+  err = new errors.ErrorHTTP('Custom cache error', 410, 'max-age=4200,s-maxage=4200');
+  t.equal(err.message, 'Custom cache error', 'sets message');
+  t.equal(err.status, 410, 'sets status');
+  t.equal(err.cache, 'max-age=4200,s-maxage=4200', 'sets custom cache');
 
   t.equal(Object.getPrototypeOf(err).toString(), 'Error', 'inherits from Error');
 

--- a/test.js
+++ b/test.js
@@ -85,6 +85,19 @@ tape('showError - ErrorHTTP with 404 status property with extra properties', (t)
   t.end();
 });
 
+tape('showError - ErrorHTTP with 403 status with custom TTL', (t) => {
+  const req = new MockReq();
+  const res = new MockRes();
+  const next = function () {};
+
+  const err = new errors.ErrorHTTP('I forbid it', 403);
+  errors.showError(err, req, res, next, 'max-age=10000,s-maxage=10000');
+
+  t.equal(res.status, 403);
+  t.equal(res.headers['Cache-Control'], 'max-age=10000,s-maxage=10000');
+  t.end();
+});
+
 tape('notFound', (t) => {
   const req = new MockReq();
   const res = new MockRes();
@@ -154,7 +167,7 @@ tape('ErrorHTTP', (t) => {
   err = new errors.ErrorHTTP(404);
   t.equal(err.message, 'Not Found', 'sets message based on status code');
   t.equal(err.status, 404, 'sets status');
-  t.equal(err.cache, 'max-age=60,s-maxage=300');
+  t.equal(err.ttl, undefined, 'no default ttl');
 
   err = new errors.ErrorHTTP('Server error');
   t.equal(err.message, 'Server error', 'sets message');
@@ -163,12 +176,12 @@ tape('ErrorHTTP', (t) => {
   err = new errors.ErrorHTTP();
   t.equal(err.message, 'Internal Server Error', 'sets message');
   t.equal(err.status, 500, 'status defaults to 500');
-  t.equal(err.cache, 'max-age=60,s-maxage=300', 'sets cache default');
+  t.equal(err.ttl, undefined, 'no default ttl');
 
   err = new errors.ErrorHTTP('Custom cache error', 410, 'max-age=4200,s-maxage=4200');
   t.equal(err.message, 'Custom cache error', 'sets message');
   t.equal(err.status, 410, 'sets status');
-  t.equal(err.cache, 'max-age=4200,s-maxage=4200', 'sets custom cache');
+  t.equal(err.ttl, 'max-age=4200,s-maxage=4200', 'sets custom cache');
 
   t.equal(Object.getPrototypeOf(err).toString(), 'Error', 'inherits from Error');
 

--- a/test.js
+++ b/test.js
@@ -80,7 +80,7 @@ tape('showError - ErrorHTTP with 404 status property with extra properties', (t)
 
   t.equal(logged, 0, 'message not logged');
   t.equal(res.status, 404);
-  t.deepEqual(res.data, { message: 'Tileset does not exist', details: 'here are the details', cache: 'max-age=60,s-maxage=300' });
+  t.deepEqual(res.data, { message: 'Tileset does not exist', details: 'here are the details' });
 
   t.end();
 });

--- a/test.js
+++ b/test.js
@@ -31,7 +31,7 @@ tape('showError', (t) => {
 
   const origlog = console.log;
   console.log = function() { logged++; };
-  errors.showError(new Error('fatal'), req, res, next, () => {});
+  errors.showError(new Error('fatal'), req, res, next);
   console.log = origlog;
 
   t.equal(logged, 1, 'message logged');
@@ -54,7 +54,7 @@ tape('showError - not 500', (t) => {
   };
   const origlog = console.log;
   console.log = function() { logged++; };
-  errors.showError(err, req, res, next, () => {});
+  errors.showError(err, req, res, next);
   console.log = origlog;
 
   t.equal(logged, 0, 'message not logged');
@@ -75,7 +75,7 @@ tape('showError - ErrorHTTP with 404 status property with extra properties', (t)
   err.details = 'here are the details';
   const origlog = console.log;
   console.log = function() { logged++; };
-  errors.showError(err, req, res, next, () => {});
+  errors.showError(err, req, res, next);
   console.log = origlog;
 
   t.equal(logged, 0, 'message not logged');
@@ -96,6 +96,34 @@ tape('showError - ErrorHTTP with 403 status with custom TTL', (t) => {
   t.equal(res.status, 403);
   t.equal(res.headers['Cache-Control'], 'max-age=10000,s-maxage=10000');
   t.end();
+});
+
+tape('showError - throws internal error on non-string TTL', (t) => {
+  const req = new MockReq();
+  const res = new MockReq();
+  const next = function () {};
+
+  const err = new errors.ErrorHTTP('It\'s gone', 410);
+  try {
+    errors.showError(err, req, res, next, 20);
+  } catch (e) {
+    t.equal(e.message, 'cache-control ttl must be a string', 'throws expected error');
+    t.end();
+  }
+});
+
+tape('showError - throws internal error on incorrect directive', (t) => {
+  const req = new MockReq();
+  const res = new MockRes();
+  const next = function () {};
+
+  const err = new errors.ErrorHTTP('I\'m a teapot', 418);
+  try {
+    errors.showError(err, req, res, next, 'coffee');
+  } catch (e) {
+    t.equal(e.message, 'invalid directive coffee');
+    t.end();
+  }
 });
 
 tape('notFound', (t) => {


### PR DESCRIPTION
While it's good practice to keep errors cached, this package would do better to set reasonable defaults for this caching rather than relying on whatever an application has set as it's default `cache-control` value, which currently happens implicitly. 

This change implements a sensible default value, while also exposing (in a non-breaking way) the ability for end users to define their own custom cache values for `ErrorHTTP` objects.

A concrete example: existing implementations will still look like:

```js
// Default messages
err = new ErrorHTTP(422);

// Custom messages
err = new ErrorHTTP('Custom explanation for what\'s broken', 422);
```

And these will automatically set the new default cache-control value of `max-age=60,s-maxage=300`.

However, users who would to set custom caching for specific errors can now do this like so:
```js
err = new ErrorHTTP('Custom error message', 404, 'max-age=43200,s-maxage=43200');
```

More importantly, this update also allows you to set default cache control for _all_ errors via the `showError` constructor. 

```js
 server.use((err, req, res, next) => {
    error.showError(err, req, res, next, 'max-age=60,s-maxage=300');
  });
```

cc/ @mapbox/maps-api