### PR TITLE
Update dependencies (fastlog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.3
+
+* Updated `@mapbox/fastlog` to version `1.3.3`, because the previous versions have an upstream dependency to vulnerable version of `minimist`.
+
 ## 3.0.2
 
 * Changed `fastlog` to private version `@mapbox/fastlog` and updated version to more recent one, which has no upstream dependency to vulnerable version of `underscore`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,24 +31,19 @@
       "dev": true
     },
     "@mapbox/fastlog": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/fastlog/-/fastlog-1.3.1.tgz",
-      "integrity": "sha512-3y9paVjbQ9uIyd5tXp57xKF+JVLT1N5S0J7J7GwU1aow18hmYJb6W3VsgFayC3o+TDusLSy8B53WlffXPqsSvw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/fastlog/-/fastlog-1.3.3.tgz",
+      "integrity": "sha512-LhaYrzDoVP4Bt/OJmJnJyjoBiGAI/Hoy8wMoiKyPk5YEIbGn66hQnsYi1UQ5RPSR8ogaxOXm9/w2nV4DIAUqtA==",
       "requires": {
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "split": "^1.0.1",
         "underscore": "^1.13.1"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
-        "underscore": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-          "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         }
       }
     },
@@ -1162,6 +1157,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "underscore": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "description": "Error middleware for express apps",
   "author": "Mapbox (https://www.mapbox.com)",
   "license": "ISC",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "main": "./index",
   "dependencies": {
-    "@mapbox/fastlog": "^1.3.1"
+    "@mapbox/fastlog": "^1.3.3"
   },
   "scripts": {
     "lint": "eslint *.js",


### PR DESCRIPTION
Updated dependencies:

- [@mapbox/fastlog](https://github.com/mapbox/fastlog): v1.3.1 -> v1.3.3


Changes in the updated dependencies:

- [@mapbox/fastlog](https://github.com/mapbox/fastlog/compare/v1.3.1...v1.3.3): updated vulnerable dependency `minimist`.

Related to https://github.com/mapbox/billing-team/issues/2305.