### PR TITLE
Allow providing a custom logger for the showError middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const logger = require('@mapbox/fastlog')();
+const fastlogLogger = require('@mapbox/fastlog')();
 const http = require('http');
 const util = require('util');
 
@@ -54,6 +54,52 @@ function fastErrorHTTP(code, status) {
 }
 
 /**
+ * Creates an express.js middleware used for showing errors in your logs
+ * and converting them to JSONP enabled response messages.
+ * 
+ * The options object allows defining a custom logger for the middleware.
+ *
+ * It will log any >=500 status codes using fastlog and update the
+ * error message to "Internal Server Error" to obfuscate any stack or
+ * native-level errors that you don't want to expose to users.
+ *
+ * Any status codes <500 are assumed to contain error messages crafted
+ * for public consumption.
+ * @param {Object} options - Options for the middleware
+ * @param {Object} options.logger Custom logger for logging the errors
+ * @param {Function} options.logger.error
+ */
+function showErrorWithOptions(options = {}) {
+  const logger = options.logger || fastlogLogger;
+  // NOTE: next is needed, even if not used, per https://expressjs.com/en/guide/using-middleware.html
+  return (err, req, res, next)  => { // eslint-disable-line no-unused-vars
+    err.status = err.status || 500;
+  
+    // Output unexpected errors to console but hide them from public eyes.
+    if (err.status >= 500) {
+      err.url = req.url;
+      err.method = req.method;
+      logger.error(err);
+      err.message = 'Internal Server Error';
+    }
+  
+    const data = { message:err.message };
+  
+    // For non-500 ErrorHTTP objects send over any additional keys.
+    // This error is one that we crafted ourselves deliberately for
+    // public consumption.
+    if (err instanceof ErrorHTTP && err.status < 500) {
+      for (const k in err) {
+        if (k === 'status') continue;
+        data[k] = err[k];
+      }
+    }
+  
+    res.status(err.status).jsonp(data);
+  }
+} 
+
+/**
  * An express.js middleware used for showing errors in your logs
  * and converting them to JSONP enabled response messages.
  *
@@ -64,33 +110,7 @@ function fastErrorHTTP(code, status) {
  * Any status codes <500 are assumed to contain error messages crafted
  * for public consumption.
  */
-
-// NOTE: next is needed, even if not used, per https://expressjs.com/en/guide/using-middleware.html
-function showError(err, req, res, next) { // eslint-disable-line no-unused-vars
-  err.status = err.status || 500;
-
-  // Output unexpected errors to console but hide them from public eyes.
-  if (err.status >= 500) {
-    err.url = req.url;
-    err.method = req.method;
-    logger.error(err);
-    err.message = 'Internal Server Error';
-  }
-
-  const data = { message:err.message };
-
-  // For non-500 ErrorHTTP objects send over any additional keys.
-  // This error is one that we crafted ourselves deliberately for
-  // public consumption.
-  if (err instanceof ErrorHTTP && err.status < 500) {
-    for (const k in err) {
-      if (k === 'status') continue;
-      data[k] = err[k];
-    }
-  }
-
-  res.status(err.status).jsonp(data);
-}
+const showError = showErrorWithOptions({ logger: fastlogLogger });
 
 /**
  * Express.js middleware for properly assigning a 404 status code for
@@ -101,4 +121,5 @@ function notFound(req, res, next) {
   next(new ErrorHTTP(404));
 }
 
-module.exports = { showError, notFound, fastErrorHTTP, ErrorHTTP };
+
+module.exports = { showError, showErrorWithOptions, notFound, fastErrorHTTP, ErrorHTTP };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-error",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -85,6 +85,25 @@ tape('showError - ErrorHTTP with 404 status property with extra properties', (t)
   t.end();
 });
 
+tape('showErrorWithOptions - Uses provided custom logger', (t) => {
+  let callCount = 0;
+  const logger = { 
+    error: () => callCount++,
+  }
+  const err = new errors.ErrorHTTP('Internal Server Error', 500);
+  err.details = 'here are the details';
+  const req = new MockReq();
+  const res = new MockRes();
+  const next = function () {};
+  const showErrors = errors.showErrorWithOptions({ logger });
+  showErrors(err, req, res, next);
+
+  t.equal(callCount, 1, 'provided custom logger was not called');
+  t.equal(res.status, 500);
+  t.deepEqual(res.data, { message: 'Internal Server Error' });
+  t.end();
+});
+
 tape('notFound', (t) => {
   const req = new MockReq();
   const res = new MockRes();


### PR DESCRIPTION
Adds a new middleware creator function `showErrorWithOptions`
- Allows configuring the middleware by passing an options object to `showErrorWithOptions`
- Allows providing a custom logger object for the `showError` middleware

How to use:
```javascript
const logger = { error: (err) => console.log(err) };
const showError = showErrorWithOptions({ logger });
server.use(showError);
```